### PR TITLE
Stop shipping a live token as the digital-out node's default value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "type": "commonjs",
     "name": "@nd-enerserve/node-red-smartpi",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "description": "nodes for the smartpi",
     "main": "node.js",
     "scripts": {

--- a/smartpi-modules-digital-out.html
+++ b/smartpi-modules-digital-out.html
@@ -15,16 +15,25 @@
       server: {
         value: 'http://127.0.0.1:1080',
       },
-      token: {
-        value:
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJlbmVyc2VydmUiLCJyb2xlIjpbInNtYXJ0cGkiLCJhZG0iLCJkaWFsb3V0IiwiY2Ryb20iLCJzdWRvIiwiYXVkaW8iLCJ2aWRlbyIsInBsdWdkZXYiLCJnYW1lcyIsInVzZXJzIiwiaW5wdXQiLCJyZW5kZXIiLCJuZXRkZXYiLCJzcGkiLCJpMmMiLCJncGlvIiwic21hcnRwaWFkbWluIiwic21hcnRwaXVzZXJzIl0sInVzZXJuYW1lIjoic21hcnRwaSJ9.ilRjtk-_p1-meNlNutQDSDacW1AOpZFhB9DVfQ4V2lQ',
-      },
       output: {
         value: 1,
       },
       readonly: {
         value: false,
       },
+    },
+    // The token lives here, not in defaults: defaults are stored in
+    // flows.json in plain text and travel with every exported or shared
+    // flow - which is how an earlier version of this node shipped a live,
+    // signed, full-access token as its default value, publicly readable in
+    // this repository. A credential is stored separately by Node-RED
+    // (encrypted, keyed by a secret the admin UI never exposes) and never
+    // included in an export. type: 'password' also means the admin UI
+    // never sends the current value back to the browser after it's been
+    // set - reasonable here, since a lost token is regenerated in the
+    // SmartPi web UI rather than looked up again in Node-RED.
+    credentials: {
+      token: { type: 'password' },
     },
     oneditsave: Save,
     oneditprepare: Restore,

--- a/smartpi-modules-digital-out.html
+++ b/smartpi-modules-digital-out.html
@@ -167,7 +167,7 @@
         <input type="text" id="node-input-server" placeholder="http://127.0.0.1:1080">
     </div>
     <div class="form-row">
-        <label for="node-input-token"> <i class="fa fa-lock"></i> Baerer-Token<span id="node-span-token" style="display:none"></span></label>
+        <label for="node-input-token"> <i class="fa fa-lock"></i> API-Token<span id="node-span-token" style="display:none"></span></label>
         <input type="password" id="node-input-token">
     </div>
     <div class="form-row">

--- a/smartpi-modules-digital-out.js
+++ b/smartpi-modules-digital-out.js
@@ -1,5 +1,47 @@
 module.exports = function (RED) {
 
+    // needle resolves the promise on every HTTP response, successful or not
+    // - a 401 lands here in .then(), not in .catch(), which only ever sees
+    // transport failures (timeouts, DNS, connection refused). Without this
+    // check a revoked or mistyped token showed up as a normal-looking
+    // message carrying the server's {"message":"Invalid token."} body, with
+    // no red status ring and no node.error() - easy to miss in a flow.
+    function handleResponse(node, msg, nodeSend, nodeDone) {
+        return function (res) {
+            msg.statusCode = res.statusCode;
+            msg.headers = res.headers;
+            msg.responseUrl = res.url;
+            msg.payload = JSON.parse(res.body);
+
+            if (res.statusCode === 401) {
+                node.error("Token invalid or revoked - generate a new one in the SmartPi web UI (Settings > API tokens) and update this node.", msg);
+                node.status({ fill: "red", shape: "ring", text: "unauthorized" });
+                nodeDone();
+                return;
+            }
+
+            msg.retry = 0;
+            node.status({});
+            nodeSend(msg);
+            nodeDone();
+        };
+    }
+
+    function handleError(node, msg, nodeSend, nodeDone, url) {
+        return function (err) {
+            if (err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT') {
+                node.error(RED._("common.notification.errors.no-response"), msg);
+                node.status({ fill: "red", shape: "ring", text: "common.notification.errors.no-response" });
+            } else {
+                node.error(err, msg);
+                node.status({ fill: "red", shape: "ring", text: err.code });
+            }
+            msg.payload = err.toString() + " : " + url;
+            msg.statusCode = err.code || (err.response ? err.response.statusCode : undefined);
+            nodeDone();
+        };
+    }
+
     function SmartPiDigitalOut(config) {
 
         var needle = require('needle');
@@ -8,6 +50,10 @@ module.exports = function (RED) {
         var node = this;
         this.indicator = config.indicator;
         this.server = config.server;
+        // The token lives in credentials (see the .html file), not in
+        // config/defaults: defaults are stored in flows.json in plain text
+        // and travel with every exported or shared flow, credentials are
+        // stored and encrypted separately by Node-RED.
         this.token = config.token;
         this.bits = config.bits;
         this.output = config.output;
@@ -64,34 +110,8 @@ module.exports = function (RED) {
                 }
 
                 needle(opts.method, url, null, options)
-                    .then(function (res) {
-
-                        msg.statusCode = res.statusCode;
-                        msg.headers = res.headers;
-                        msg.responseUrl = res.url;
-                        msg.payload = JSON.parse(res.body);
-
-                        msg.retry = 0;
-
-                        node.status({});
-                        nodeSend(msg);
-                        nodeDone();
-
-                    })
-                    .catch(function (err) {
-
-                        if (err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT') {
-                            node.error(RED._("common.notification.errors.no-response"), msg);
-                            node.status({ fill: "red", shape: "ring", text: "common.notification.errors.no-response" });
-                        } else {
-                            node.error(err, msg);
-                            node.status({ fill: "red", shape: "ring", text: err.code });
-                        }
-                        msg.payload = err.toString() + " : " + url;
-                        msg.statusCode = err.code || (err.response ? err.response.statusCode : undefined);
-                        nodeDone();
-
-                    });
+                    .then(handleResponse(node, msg, nodeSend, nodeDone))
+                    .catch(handleError(node, msg, nodeSend, nodeDone, url));
 
 
             } else if (msg.payload.port) {
@@ -157,34 +177,8 @@ module.exports = function (RED) {
                 }
 
                 needle(opts.method, url, null, options)
-                    .then(function (res) {
-
-                        msg.statusCode = res.statusCode;
-                        msg.headers = res.headers;
-                        msg.responseUrl = res.url;
-                        msg.payload = JSON.parse(res.body);
-
-                        msg.retry = 0;
-
-                        node.status({});
-                        nodeSend(msg);
-                        nodeDone();
-
-                    })
-                    .catch(function (err) {
-
-                        if (err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT') {
-                            node.error(RED._("common.notification.errors.no-response"), msg);
-                            node.status({ fill: "red", shape: "ring", text: "common.notification.errors.no-response" });
-                        } else {
-                            node.error(err, msg);
-                            node.status({ fill: "red", shape: "ring", text: err.code });
-                        }
-                        msg.payload = err.toString() + " : " + url;
-                        msg.statusCode = err.code || (err.response ? err.response.statusCode : undefined);
-                        nodeDone();
-
-                    });
+                    .then(handleResponse(node, msg, nodeSend, nodeDone))
+                    .catch(handleError(node, msg, nodeSend, nodeDone, url));
 
 
             } else {

--- a/smartpi-modules-digital-out.js
+++ b/smartpi-modules-digital-out.js
@@ -53,8 +53,10 @@ module.exports = function (RED) {
         // The token lives in credentials (see the .html file), not in
         // config/defaults: defaults are stored in flows.json in plain text
         // and travel with every exported or shared flow, credentials are
-        // stored and encrypted separately by Node-RED.
-        this.token = config.token;
+        // stored and encrypted separately by Node-RED. Credentials are not
+        // part of `config` - RED.nodes.createNode(this, config) above is
+        // what populates this.credentials, so it has to be read from there.
+        this.token = this.credentials.token;
         this.bits = config.bits;
         this.output = config.output;
         this.readonly = config.readonly;


### PR DESCRIPTION
Part of the revocable device token migration. Companions:
- SmartPi: nDenerserve/SmartPi#278
- SmartPi-GUI: nDenerserve/SmartPi-GUI#1

### Why

This node's default token value was not a placeholder - it was a real, signed token with full access (`smartpiadmin`, `smartpiusers` among its roles), publicly readable by anyone who opens this repository or installs this package. On any SmartPi that never changed its appkey, it is a working admin credential.

### What

The `token` field moves from `defaults` to `credentials`. `defaults` are stored in `flows.json` in plain text and travel with every exported or shared flow - which is how the old default ended up here in the first place. A credential is stored separately by Node-RED, encrypted, and never included in an export. The admin UI's input was already `type="password"`; only the field's classification needed to change, the template did not.

There is no default value anymore - the field starts empty. A device token generated in the SmartPi web UI's new "API tokens" tab (nDenerserve/SmartPi-GUI#1) belongs here instead. That token is scoped (grant it just `digitalout`) and revocable by deleting it in the web UI, unlike the token this replaces.

Also handles a 401 explicitly. `needle` resolves its promise on every HTTP response, successful or not, so a revoked or mistyped token landed in `.then()` looking like any other message - the server's `{"message":"Invalid token."}` body, no red status ring, no `node.error()`. It now surfaces as a clear error pointing at where to get a new token.

Version bumped to 0.2.7.

### Note for the release

Removing the value from this repository does not revoke it on existing installations - it is still valid wherever the appkey was never changed, and it stays in this repository's git history. Only rotating that installation's appkey does. Worth calling out to users when this is released.

### Verification

`node --check` on both the module and the extracted inline script from the `.html` editor panel; no test suite in this repository to run beyond that.
