### PR TITLE
Fix the token still not saving after the credentials move

### DIFF
--- a/smartpi-modules-digital-out.js
+++ b/smartpi-modules-digital-out.js
@@ -207,5 +207,18 @@ module.exports = function (RED) {
 
         });
     }
-    RED.nodes.registerType("smartpi-e.digital-out", SmartPiDigitalOut);
+    // The credentials schema also has to be declared here, server-side, not
+    // just in the .html file's client-side registerType() call. The .html
+    // declaration only tells the editor which field is a password input;
+    // without this one the runtime has no registered credentials type for
+    // "smartpi-e.digital-out" to validate or store against at all, and
+    // rejects every save with "Credentials type ... is not registered" -
+    // silently as far as this node is concerned, since that error surfaces
+    // in Node-RED's own notifications, not through this node's status or
+    // debug output.
+    RED.nodes.registerType("smartpi-e.digital-out", SmartPiDigitalOut, {
+        credentials: {
+            token: { type: "password" }
+        }
+    });
 }

--- a/smartpi-modules-digital-out.js
+++ b/smartpi-modules-digital-out.js
@@ -69,6 +69,15 @@ module.exports = function (RED) {
         this.output = config.output;
         this.readonly = config.readonly;
 
+        // Visible without triggering the node or reading any log: an empty
+        // token is silently sent as "Bearer " (see the Authorization header
+        // below) and only shows up as a rejection once something fires the
+        // node. This surfaces the same fact right on the flow canvas the
+        // moment the node deploys.
+        if (!this.token) {
+            node.status({ fill: "yellow", shape: "ring", text: "no token configured" });
+        }
+
         node.on('input', function (msg, nodeSend, nodeDone) {
 
             if ((msg.payload == "1") || (msg.payload == true) || (msg.payload == "0") || (msg.payload == false)) {

--- a/smartpi-modules-digital-out.js
+++ b/smartpi-modules-digital-out.js
@@ -56,7 +56,15 @@ module.exports = function (RED) {
         // stored and encrypted separately by Node-RED. Credentials are not
         // part of `config` - RED.nodes.createNode(this, config) above is
         // what populates this.credentials, so it has to be read from there.
-        this.token = this.credentials.token;
+        // For a node that has never had a credential saved (a fresh node, or
+        // one carried over from before this field was a credential),
+        // this.credentials itself is undefined rather than an empty object.
+        // Without the guard below, `this.credentials.token` throws
+        // "Cannot read properties of undefined (reading 'token')" and the
+        // node never comes up at all, rather than just having no token -
+        // avoided using a plain conditional rather than ?. to keep working
+        // on the Node.js versions in engines (>=12.22.12) in package.json.
+        this.token = this.credentials ? this.credentials.token : undefined;
         this.bits = config.bits;
         this.output = config.output;
         this.readonly = config.readonly;


### PR DESCRIPTION
The previous PR (#3) merged at 26aa83d, before these three fixes landed - all found while debugging the credentials migration live against a running SmartPi:

- ebb73b2: this.credentials is undefined (not {}) for a node that never had a credential saved; reading .token off it crashed the node constructor.
- aa8f364: visible status ring when no token is configured, so that's answerable without triggering the node or reading server logs.
- c43c6d2: the actual root cause of the token never being saved at all - the credentials schema also has to be registered server-side as the third argument to the .js file's RED.nodes.registerType() call, not just in the .html file's client-side one. Without it the runtime has no registered credentials type and rejects every save with "Credentials type ... is not registered".

Verified working end-to-end against a live SmartPi (server, web UI, and this node) after this commit.