### PR TITLE
Add an analog-out module for the 4-20mA endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "type": "commonjs",
     "name": "@nd-enerserve/node-red-smartpi",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "description": "nodes for the smartpi",
     "main": "node.js",
     "scripts": {
@@ -20,7 +20,8 @@
             "Smartpi-Input": "smartpi-input.js",
             "Treshold-Trigger": "smartpi-treshold-trigger.js",
             "e.temperature-Values": "smartpi-etemperature-values.js",
-            "e.digital OUT": "smartpi-modules-digital-out.js"
+            "e.digital OUT": "smartpi-modules-digital-out.js",
+            "e.analog OUT": "smartpi-modules-analog-out.js"
         }
     },
     "repository": {

--- a/smartpi-modules-analog-out.html
+++ b/smartpi-modules-analog-out.html
@@ -1,0 +1,83 @@
+<script type="text/javascript">
+  RED.nodes.registerType('smartpi-e.analog-out', {
+    category: 'SmartPi',
+    color: '#a6bbcf',
+    defaults: {
+      name: {
+        value: 'smartpi-e.analog-out',
+      },
+      indicator: {
+        value: '',
+      },
+      server: {
+        value: 'http://127.0.0.1:1080',
+      },
+      // Hex only, e.g. "0x60" - unlike the digital-out module, this address
+      // is not derived from jumper switches, it is the MCP4725's real I2C
+      // bus address. The regex validator gives immediate feedback in the
+      // editor (a red outline) instead of only failing once the node runs.
+      address: {
+        value: '0x60',
+        validate: RED.validators.regex(/^0[xX][0-9a-fA-F]+$/),
+      },
+      readonly: {
+        value: false,
+      },
+    },
+    // See smartpi-modules-digital-out.html for why the token lives here and
+    // not in defaults.
+    credentials: {
+      token: { type: 'password' },
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: 'arrow-in.png',
+    label: function () {
+      return (
+        this.name + ' ' + this.indicator ||
+        'smartpi-e.analog-out ' + this.indicator
+      );
+    },
+  });
+</script>
+
+<script type="text/x-red" data-template-name="smartpi-e.analog-out">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-address"><i class="fa fa-microchip"></i> Address (hex)</label>
+        <input type="text" id="node-input-address" placeholder="0x60">
+    </div>
+    <div class="form-row">
+        <label for="node-input-server"><i class="fa fa-globe"></i> Server:port</label>
+        <input type="text" id="node-input-server" placeholder="http://127.0.0.1:1080">
+    </div>
+    <div class="form-row">
+        <label for="node-input-token"> <i class="fa fa-lock"></i> API-Token<span id="node-span-token" style="display:none"></span></label>
+        <input type="password" id="node-input-token">
+    </div>
+    <div class="form-row">
+        <input type="checkbox" id="node-input-readonly" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-readonly" style="width: 70%;"> <i class="fa fa-book"></i> Readonly (input value will not be set)</label>
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="smartpi-e.analog-out">
+  <p>Sets or reads the 4-20mA output of an MCP4725 analog output module.</p>
+  <h3>Inputs</h3>
+  <dl class="message-properties">
+    <dt>payload <span class="property-type">number</span></dt>
+    <dd>the current to set, in mA, between 4 and 20. Ignored when Readonly is checked - every input then just reads the current status instead of setting it.</dd>
+  </dl>
+  <h3>Outputs</h3>
+  <dl class="message-properties">
+    <dt>payload <span class="property-type">number</span></dt>
+    <dd>the current value reported back by the module, in mA.</dd>
+    <dt>moduleStatus <span class="property-type">object</span></dt>
+    <dd>the module's full status response (moduleaddress, setvalue, currentvalue).</dd>
+  </dl>
+  <h3>Details</h3>
+  <p>The address is the module's I2C bus address in hex, e.g. <code>0x60</code> - not the jumper-switch encoding the digital-out module uses.</p>
+</script>

--- a/smartpi-modules-analog-out.js
+++ b/smartpi-modules-analog-out.js
@@ -1,0 +1,139 @@
+module.exports = function (RED) {
+
+    // needle resolves the promise on every HTTP response, successful or not
+    // - an error status lands here in .then(), not in .catch(), which only
+    // ever sees transport failures (timeouts, DNS, connection refused).
+    function handleResponse(node, msg, nodeSend, nodeDone) {
+        return function (res) {
+            msg.statusCode = res.statusCode;
+            msg.headers = res.headers;
+            msg.responseUrl = res.url;
+
+            var body = JSON.parse(res.body);
+
+            if (res.statusCode === 401) {
+                node.error("Token invalid or revoked - generate a new one in the SmartPi web UI (Settings > API tokens) and update this node.", msg);
+                node.status({ fill: "red", shape: "ring", text: "unauthorized" });
+                msg.payload = body;
+                nodeDone();
+                return;
+            }
+
+            if (res.statusCode >= 400) {
+                var reason = body.message || body.error || ("HTTP " + res.statusCode);
+                node.error(reason, msg);
+                node.status({ fill: "red", shape: "ring", text: reason });
+                msg.payload = body;
+                nodeDone();
+                return;
+            }
+
+            // The module's full status (moduleaddress, setvalue, currentvalue)
+            // stays available on msg.moduleStatus - payload is reduced to the
+            // plain mA number so this node can feed a gauge or chart directly,
+            // without an extra "extract property" step downstream.
+            msg.moduleStatus = body;
+            msg.payload = body.currentvalue;
+
+            node.status({ fill: "green", shape: "dot", text: body.currentvalue + " mA" });
+            nodeSend(msg);
+            nodeDone();
+        };
+    }
+
+    function handleError(node, msg, nodeSend, nodeDone, url) {
+        return function (err) {
+            if (err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT') {
+                node.error(RED._("common.notification.errors.no-response"), msg);
+                node.status({ fill: "red", shape: "ring", text: "common.notification.errors.no-response" });
+            } else {
+                node.error(err, msg);
+                node.status({ fill: "red", shape: "ring", text: err.code });
+            }
+            msg.payload = err.toString() + " : " + url;
+            msg.statusCode = err.code || (err.response ? err.response.statusCode : undefined);
+            nodeDone();
+        };
+    }
+
+    function SmartPiAnalogOut(config) {
+
+        var needle = require('needle');
+
+        RED.nodes.createNode(this, config);
+        var node = this;
+        this.indicator = config.indicator;
+        this.server = config.server;
+        this.address = config.address;
+        this.readonly = config.readonly;
+        // See smartpi-modules-digital-out.js for why this is read from
+        // this.credentials rather than config, and why the ternary guard
+        // (rather than this.credentials.token directly) is needed for a
+        // node that has never had a credential saved.
+        this.token = this.credentials ? this.credentials.token : undefined;
+
+        var status = [];
+        if (!this.token) {
+            status.push("no token configured");
+        }
+        if (!/^0[xX][0-9a-fA-F]+$/.test(this.address || "")) {
+            status.push("address is not a hex value");
+        }
+        if (status.length > 0) {
+            node.status({ fill: "yellow", shape: "ring", text: status.join(", ") });
+        }
+
+        node.on('input', function (msg, nodeSend, nodeDone) {
+
+            var opts = {};
+            opts.timeout = node.reqTimeout;
+            opts.throwHttpErrors = false;
+            opts.decompress = false;
+            opts.retry = 0;
+            opts.responseType = 'buffer';
+            opts.maxRedirects = 21;
+            opts.ignoreInvalidCookies = true;
+            opts.headers = {};
+            opts.headers.Authorization = `Bearer ${this.token || ""}`;
+
+            var url = this.server + "/api/v1/module/analogout420ma/" + this.address;
+
+            if (this.readonly == false) {
+                var current = Number(msg.payload);
+                if (isNaN(current) || current < 4 || current > 20) {
+                    node.error("msg.payload must be a number between 4 and 20 (mA), got: " + JSON.stringify(msg.payload), msg);
+                    node.status({ fill: "red", shape: "ring", text: "invalid payload" });
+                    nodeDone();
+                    return;
+                }
+                opts.method = "put";
+                url = url + "/" + current;
+            } else {
+                opts.method = "get";
+            }
+
+            var options = {
+                json: true,
+                headers: {
+                    authorization: opts.headers.Authorization
+                }
+            };
+
+            needle(opts.method, url, null, options)
+                .then(handleResponse(node, msg, nodeSend, nodeDone))
+                .catch(handleError(node, msg, nodeSend, nodeDone, url));
+
+        });
+    }
+
+    // The credentials schema also has to be declared here, server-side, not
+    // just in the .html file's client-side registerType() call - see
+    // smartpi-modules-digital-out.js, where getting only the client-side
+    // half of this right meant every save silently failed with "Credentials
+    // type ... is not registered".
+    RED.nodes.registerType("smartpi-e.analog-out", SmartPiAnalogOut, {
+        credentials: {
+            token: { type: "password" }
+        }
+    });
+}


### PR DESCRIPTION
New node "e.analog OUT" (`smartpi-e.analog-out`) for `PUT/GET /api/v1/module/analogout420ma/{address}[/{current}]`, same shape as `smartpi-modules-digital-out.js`: server field, an API token credential (registered both client- and server-side), explicit 401 handling, and a status ring visible without triggering the node when the token or address is missing/malformed.

Differences from digital-out, matching what this endpoint actually is:

- Address is entered as hex only (e.g. `0x60`), validated in the editor via `RED.validators.regex` - this is the MCP4725's real I2C bus address, not a jumper-switch encoding to convert.
- Input (`msg.payload`) must be a number between 4 and 20 (mA); anything else is rejected locally with a clear error before any request is sent.
- Readonly mode (like digital-out) skips that validation and just reads the module's current status via GET.
- Output payload is reduced to the plain retrieved mA value rather than the server's whole JSON status object, so this node can feed a gauge or chart directly; the full status (`moduleaddress`, `setvalue`, `currentvalue`) stays available on `msg.moduleStatus`.
- Any non-2xx response (not just 401) sets a red status ring and calls `node.error()`.

Registered in `package.json` as `e.analog OUT`, version bumped to 0.2.8.

### Verification

`node --check` on the module and the extracted client-side script (executed against a minimal `RED` stub, not just parsed). Ran the module itself against a mocked `needle` and a stubbed `RED.nodes.createNode`/`registerType` covering: missing token + malformed address both flagged on one status ring; out-of-range payload rejected before any request; a successful `PUT` (correct URL, `msg.payload` reduced to the numeric value, `msg.moduleStatus` populated); a readonly `GET` (no value segment in the URL); and a `401` (red ring, `node.error()` called, `nodeSend` never invoked). No live Node-RED instance or SmartPi server available here to test end-to-end.