### PR TITLE
Add optional periodic status polling to both output modules

### DIFF
--- a/smartpi-modules-analog-out.html
+++ b/smartpi-modules-analog-out.html
@@ -23,6 +23,13 @@
       readonly: {
         value: false,
       },
+      // Seconds between independent status reads; 0 disables polling
+      // entirely (the node only reacts to input, same as before this
+      // existed).
+      pollInterval: {
+        value: 0,
+        validate: RED.validators.number(),
+      },
     },
     // See smartpi-modules-digital-out.html for why the token lives here and
     // not in defaults.
@@ -62,6 +69,10 @@
         <input type="checkbox" id="node-input-readonly" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="node-input-readonly" style="width: 70%;"> <i class="fa fa-book"></i> Readonly (input value will not be set)</label>
     </div>
+    <div class="form-row">
+        <label for="node-input-pollInterval"><i class="fa fa-refresh"></i> Poll interval (s)</label>
+        <input type="number" id="node-input-pollInterval" min="0" step="1" placeholder="0 = off" style="width: 100px;">
+    </div>
 </script>
 
 <script type="text/x-red" data-help-name="smartpi-e.analog-out">
@@ -80,4 +91,5 @@
   </dl>
   <h3>Details</h3>
   <p>The address is the module's I2C bus address in hex, e.g. <code>0x60</code> - not the jumper-switch encoding the digital-out module uses.</p>
+  <p>The MCP4725 has no DAC readback, so a set value's response is only ever an echo of what was requested. Set "Poll interval" (seconds) to have the node independently re-read and output the module's actual status on that schedule, regardless of input. 0 disables polling.</p>
 </script>

--- a/smartpi-modules-analog-out.js
+++ b/smartpi-modules-analog-out.js
@@ -83,6 +83,42 @@ module.exports = function (RED) {
             node.status({ fill: "yellow", shape: "ring", text: status.join(", ") });
         }
 
+        // Optional independent polling: the MCP4725 this module drives has
+        // no DAC readback (see the Go repository's SetAnalogOut420mA), so a
+        // PUT's response is only ever an echo of what was just requested,
+        // never a genuinely retrieved value. A periodic GET, independent of
+        // whatever was last set, is the only way this node can output a
+        // value that actually came from the server rather than from its own
+        // last input. Off (no timer at all) unless a positive interval is
+        // configured.
+        var pollInterval = Number(config.pollInterval);
+        var pollTimer = null;
+        function poll() {
+            var opts = {};
+            opts.headers = {};
+            opts.headers.Authorization = `Bearer ${node.token || ""}`;
+
+            var url = node.server + "/api/v1/module/analogout420ma/" + node.address;
+            var options = {
+                json: true,
+                headers: { authorization: opts.headers.Authorization }
+            };
+
+            needle("get", url, null, options)
+                .then(handleResponse(node, {}, function (msg) { node.send(msg); }, function () {}))
+                .catch(handleError(node, {}, function (msg) { node.send(msg); }, function () {}, url));
+        }
+        if (pollInterval > 0) {
+            pollTimer = setInterval(poll, pollInterval * 1000);
+        }
+        node.on('close', function (done) {
+            if (pollTimer) {
+                clearInterval(pollTimer);
+                pollTimer = null;
+            }
+            done();
+        });
+
         node.on('input', function (msg, nodeSend, nodeDone) {
 
             var opts = {};

--- a/smartpi-modules-digital-out.html
+++ b/smartpi-modules-digital-out.html
@@ -21,6 +21,13 @@
       readonly: {
         value: false,
       },
+      // Seconds between independent status reads; 0 disables polling
+      // entirely (the node only reacts to input, same as before this
+      // existed).
+      pollInterval: {
+        value: 0,
+        validate: RED.validators.number(),
+      },
     },
     // The token lives here, not in defaults: defaults are stored in
     // flows.json in plain text and travel with every exported or shared
@@ -173,6 +180,10 @@
     <div class="form-row">
         <input type="checkbox" id="node-input-readonly" style="display: inline-block; width: auto; vertical-align: top;">
         <label for="node-input-readonly" style="width: 70%;"> <i class="fa fa-book"></i> Readonly (Outputs will not set)</label>
+    </div>
+    <div class="form-row">
+        <label for="node-input-pollInterval"><i class="fa fa-refresh"></i> Poll interval (s)</label>
+        <input type="number" id="node-input-pollInterval" min="0" step="1" placeholder="0 = off" style="width: 100px;">
     </div>
 </script>
 

--- a/smartpi-modules-digital-out.js
+++ b/smartpi-modules-digital-out.js
@@ -42,6 +42,17 @@ module.exports = function (RED) {
         };
     }
 
+    // Renders the jumper-switch bit pattern the same way both input branches
+    // and the periodic poll below need it, as the URL path segment
+    // identifying which module to address.
+    function bitsToAddress(bits) {
+        var address = "";
+        for (let element of bits) {
+            address += element ? "1" : "0";
+        }
+        return address;
+    }
+
     function SmartPiDigitalOut(config) {
 
         var needle = require('needle');
@@ -78,6 +89,39 @@ module.exports = function (RED) {
             node.status({ fill: "yellow", shape: "ring", text: "no token configured" });
         }
 
+        // Optional independent polling: reads the module's actual port
+        // status on a timer, regardless of whether or when an input last
+        // set anything. Off (no timer at all) unless a positive interval is
+        // configured - a 0/empty/invalid value must not silently poll every
+        // few milliseconds.
+        var pollInterval = Number(config.pollInterval);
+        var pollTimer = null;
+        function poll() {
+            var opts = {};
+            opts.headers = {};
+            opts.headers.Authorization = `Bearer ${node.token || ""}`;
+
+            var url = node.server + "/api/v1/module/digitalout/" + bitsToAddress(node.bits);
+            var options = {
+                json: true,
+                headers: { authorization: opts.headers.Authorization }
+            };
+
+            needle("get", url, null, options)
+                .then(handleResponse(node, {}, function (msg) { node.send(msg); }, function () {}))
+                .catch(handleError(node, {}, function (msg) { node.send(msg); }, function () {}, url));
+        }
+        if (pollInterval > 0) {
+            pollTimer = setInterval(poll, pollInterval * 1000);
+        }
+        node.on('close', function (done) {
+            if (pollTimer) {
+                clearInterval(pollTimer);
+                pollTimer = null;
+            }
+            done();
+        });
+
         node.on('input', function (msg, nodeSend, nodeDone) {
 
             if ((msg.payload == "1") || (msg.payload == true) || (msg.payload == "0") || (msg.payload == false)) {
@@ -102,15 +146,7 @@ module.exports = function (RED) {
                 opts.headers.Authorization = `Bearer ${this.token || ""}`
 
 
-                var url = this.server + "/api/v1/module/digitalout/";
-
-                for (let element of this.bits) {
-                    if (element == false) {
-                        url = url + "0"
-                    } else if (element == true) {
-                        url = url + "1"
-                    }
-                }
+                var url = this.server + "/api/v1/module/digitalout/" + bitsToAddress(this.bits);
 
                 if (this.readonly == false) {
                     url = url + "/" + this.output + "=";
@@ -154,15 +190,7 @@ module.exports = function (RED) {
                 opts.headers.Authorization = `Bearer ${this.token || ""}`
 
 
-                var url = this.server + "/api/v1/module/digitalout/";
-
-                for (let element of this.bits) {
-                    if (element == false) {
-                        url = url + "0"
-                    } else if (element == true) {
-                        url = url + "1"
-                    }
-                }
+                var url = this.server + "/api/v1/module/digitalout/" + bitsToAddress(this.bits);
 
                 if ((msg.payload.port.length == 4) && (this.readonly == false)) {
 


### PR DESCRIPTION
Stacked on #5 (the new analog-out module) - this PR's own diff is only the polling addition.

New "Poll interval (s)" field on both `smartpi-e.digital-out` and `smartpi-e.analog-out`. `0` (the default) disables it entirely - no timer is created, nothing changes for anyone not using this. A positive value starts an independent `setInterval` that issues a GET against the module's status endpoint on that schedule and emits the result via `node.send()`, regardless of whether or when an input last set anything. Cleared on the node's `close` event, so a redeploy does not leak timers.

### Why

Motivated by the analog-out module specifically: the MCP4725 it drives has no DAC readback (see the Go repository's `SetAnalogOut420mA`, which just echoes the requested value back as both `setvalue` and `currentvalue`), so up to now the only way to see any output from that node was that echo - never a value that actually came from the server independent of the last input. A periodic GET, on its own schedule, is the only way to get that.

digital-out gets the same field for parity, even though its SET already reads the real GPIO pin state back, so it does not have the same gap - there it is a convenience, not a fix for a missing measurement.

`bitsToAddress()` factors the jumper-bits-to-URL-segment conversion out of `digital-out.js`, previously duplicated in both input branches and now needed a third time for the poll function.

### Verification

Against a stubbed `RED` runtime (not just parsed): `pollInterval` 0 creates no timer at all; a short interval fires repeatedly at the configured cadence and sends output (numeric payload + `moduleStatus` for analog-out, the full status object for digital-out, unchanged); `node.on('close')` stops the timer, confirmed by no further calls afterwards. Re-ran the existing input-validation, success-path and 401-handling tests from #5 unchanged, all still pass. No live Node-RED instance or SmartPi server available here to test end-to-end.