### PR TITLE
Add an analog-in module for /api/v1/module/analogin

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
             "Treshold-Trigger": "smartpi-treshold-trigger.js",
             "e.temperature-Values": "smartpi-etemperature-values.js",
             "e.digital OUT": "smartpi-modules-digital-out.js",
-            "e.analog OUT": "smartpi-modules-analog-out.js"
+            "e.analog OUT": "smartpi-modules-analog-out.js",
+            "e.analog IN": "smartpi-modules-analog-in.js"
         }
     },
     "repository": {

--- a/smartpi-modules-analog-in.html
+++ b/smartpi-modules-analog-in.html
@@ -1,0 +1,230 @@
+<script type="text/javascript">
+  RED.nodes.registerType('smartpi-e.analog-in', {
+    category: 'SmartPi',
+    color: '#a6bbcf',
+    defaults: {
+      name: {
+        value: 'smartpi-e.analog-in',
+      },
+      indicator: {
+        value: '',
+      },
+      server: {
+        value: 'http://127.0.0.1:1080',
+      },
+      // Hex only, e.g. "0x68" - the MCP3424's real I2C bus address, same as
+      // the analog-out module's address field.
+      address: {
+        value: '0x68',
+        validate: RED.validators.regex(/^0[xX][0-9a-fA-F]+$/),
+      },
+      // One entry per physical channel/jumper - true = 4-20mA (current),
+      // false = 0-10V (voltage). Mirrors the digital-out module's bits
+      // array, but each entry here has its own independent meaning rather
+      // than together encoding one address.
+      channelTypes: {
+        value: [true, true, true, true],
+      },
+      // Seconds between independent status reads; 0 disables polling
+      // entirely (the node only reacts to input).
+      pollInterval: {
+        value: 0,
+        validate: RED.validators.number(),
+      },
+    },
+    // See smartpi-modules-digital-out.html for why the token lives here and
+    // not in defaults.
+    credentials: {
+      token: { type: 'password' },
+    },
+    oneditsave: Save,
+    oneditprepare: Restore,
+    inputs: 1,
+    outputs: 1,
+    icon: 'arrow-in.png',
+    label: function () {
+      return (
+        this.name + ' ' + this.indicator ||
+        'smartpi-e.analog-in ' + this.indicator
+      );
+    },
+  });
+
+  function Save() {
+    const NumChannels = 4;
+    this.channelTypes = [];
+    for (let i = 0; i < NumChannels; i++) {
+      this.channelTypes.push($(`#analoginCh${i}`).is(':checked'));
+    }
+  }
+
+  function Restore() {
+    for (let i = 0; i < this.channelTypes.length; i++) {
+      $(`#analoginCh${i}`).prop('checked', this.channelTypes[i]);
+    }
+  }
+</script>
+
+<script type="text/x-red" data-template-name="smartpi-e.analog-in">
+
+    <style>
+        .labelleft {
+            float: left;
+            width: 150px !important;
+        }
+
+        .customswitch {
+            position: relative;
+            display: inline-block;
+            width: 23px !important;
+            height: 40px;
+            vertical-align: middle;
+        }
+
+        .customswitch input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+
+        .slider {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: #ccc;
+            -webkit-transition: .4s;
+            transition: .4s;
+        }
+
+        .slider:before {
+            position: absolute;
+            content: "";
+            height: 17px;
+            width: 17px;
+            left: 3px;
+            bottom: 3px;
+            background-color: white;
+            -webkit-transition: .4s;
+            transition: .4s;
+        }
+
+        input:checked+.slider {
+            background-color: #2196F3;
+        }
+
+        input:focus+.slider {
+            box-shadow: 0 0 1px #2196F3;
+        }
+
+        input:checked+.slider:before {
+            -webkit-transform: translateY(-17px);
+            -ms-transform: translateY(-17px);
+            transform: translateY(-17px);
+        }
+
+        .slider.round {
+            border-radius: 23px;
+        }
+
+        .slider.round:before {
+            border-radius: 50%;
+        }
+
+        .channelrow {
+            margin-bottom: 8px;
+        }
+
+        .channelunit {
+            display: inline-block;
+            width: 60px;
+            text-align: center;
+            font-size: 0.85em;
+            color: #666;
+        }
+    </style>
+
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="name">
+    </div>
+    <div class="form-row">
+        <label for="node-input-address"><i class="fa fa-microchip"></i> Address (hex)</label>
+        <input type="text" id="node-input-address" placeholder="0x68">
+    </div>
+    <div class="form-row">
+        <label class="labelleft"><i class="fa fa-sliders"></i> Channel jumpers</label>
+    </div>
+    <div class="form-row channelrow">
+        <label class="labelleft" style="width: 90px !important; padding-left: 20px;">Channel 1</label>
+        <span class="channelunit">0-10V</span>
+        <label class="customswitch">
+            <input type="checkbox" id="analoginCh0">
+            <span class="slider round"></span>
+        </label>
+        <span class="channelunit">4-20mA</span>
+    </div>
+    <div class="form-row channelrow">
+        <label class="labelleft" style="width: 90px !important; padding-left: 20px;">Channel 2</label>
+        <span class="channelunit">0-10V</span>
+        <label class="customswitch">
+            <input type="checkbox" id="analoginCh1">
+            <span class="slider round"></span>
+        </label>
+        <span class="channelunit">4-20mA</span>
+    </div>
+    <div class="form-row channelrow">
+        <label class="labelleft" style="width: 90px !important; padding-left: 20px;">Channel 3</label>
+        <span class="channelunit">0-10V</span>
+        <label class="customswitch">
+            <input type="checkbox" id="analoginCh2">
+            <span class="slider round"></span>
+        </label>
+        <span class="channelunit">4-20mA</span>
+    </div>
+    <div class="form-row channelrow">
+        <label class="labelleft" style="width: 90px !important; padding-left: 20px;">Channel 4</label>
+        <span class="channelunit">0-10V</span>
+        <label class="customswitch">
+            <input type="checkbox" id="analoginCh3">
+            <span class="slider round"></span>
+        </label>
+        <span class="channelunit">4-20mA</span>
+    </div>
+    <div class="form-row">
+        <label for="node-input-server"><i class="fa fa-globe"></i> Server:port</label>
+        <input type="text" id="node-input-server" placeholder="http://127.0.0.1:1080">
+    </div>
+    <div class="form-row">
+        <label for="node-input-token"> <i class="fa fa-lock"></i> API-Token<span id="node-span-token" style="display:none"></span></label>
+        <input type="password" id="node-input-token">
+    </div>
+    <div class="form-row">
+        <label for="node-input-pollInterval"><i class="fa fa-refresh"></i> Poll interval (s)</label>
+        <input type="number" id="node-input-pollInterval" min="0" step="1" placeholder="0 = off" style="width: 100px;">
+    </div>
+</script>
+
+<script type="text/x-red" data-help-name="smartpi-e.analog-in">
+  <p>Reads a 4-channel MCP3424-based analog input module (4-20mA and/or 0-10V per channel).</p>
+  <h3>Inputs</h3>
+  <dl class="message-properties">
+    <dt>payload <span class="property-type">any</span></dt>
+    <dd>ignored - any input message just triggers a read of all four channels.</dd>
+  </dl>
+  <h3>Outputs</h3>
+  <dl class="message-properties">
+    <dt>payload <span class="property-type">array</span></dt>
+    <dd>the four resolved readings in channel order, each already in the unit its jumper is set to (mA or V).</dd>
+    <dt>channels <span class="property-type">array</span></dt>
+    <dd>the same four readings as objects: <code>{channel, type, unit, value}</code>.</dd>
+    <dt>moduleStatus <span class="property-type">object</span></dt>
+    <dd>the server's raw, unfiltered response - both a current and a voltage reading for every channel, regardless of jumper.</dd>
+  </dl>
+  <h3>Details</h3>
+  <p>The address is the module's I2C bus address in hex, e.g. <code>0x68</code>.</p>
+  <p>Each channel's jumper on the physical module selects 4-20mA or 0-10V; the server cannot read that jumper over I2C, so it always returns both readings for every channel. Set the matching toggle per channel here so <code>payload</code> and <code>channels</code> report the one that is actually wired - the other reading is still available on <code>moduleStatus</code> if needed.</p>
+  <p>Set "Poll interval" (seconds) to have the node independently re-read all four channels on that schedule, regardless of input. 0 disables polling.</p>
+</script>

--- a/smartpi-modules-analog-in.js
+++ b/smartpi-modules-analog-in.js
@@ -1,0 +1,163 @@
+module.exports = function (RED) {
+
+    // needle resolves the promise on every HTTP response, successful or not
+    // - an error status lands here in .then(), not in .catch(), which only
+    // ever sees transport failures (timeouts, DNS, connection refused).
+    function handleResponse(node, msg, nodeSend, nodeDone) {
+        return function (res) {
+            msg.statusCode = res.statusCode;
+            msg.headers = res.headers;
+            msg.responseUrl = res.url;
+
+            var body = JSON.parse(res.body);
+
+            if (res.statusCode === 401) {
+                node.error("Token invalid or revoked - generate a new one in the SmartPi web UI (Settings > API tokens) and update this node.", msg);
+                node.status({ fill: "red", shape: "ring", text: "unauthorized" });
+                msg.payload = body;
+                nodeDone();
+                return;
+            }
+
+            if (res.statusCode >= 400) {
+                var reason = body.message || body.error || ("HTTP " + res.statusCode);
+                node.error(reason, msg);
+                node.status({ fill: "red", shape: "ring", text: reason });
+                msg.payload = body;
+                nodeDone();
+                return;
+            }
+
+            // The server has no way to know which jumper each channel is
+            // wired for, so it always returns both a current and a voltage
+            // reading per channel - node.channelTypes (one checkbox per
+            // physical jumper, set in this node's config) picks the one
+            // that is actually meaningful for that channel.
+            var resolved = body.channels.map(function (ch, i) {
+                var isCurrent = node.channelTypes[i];
+                return {
+                    channel: i + 1,
+                    type: isCurrent ? "current" : "voltage",
+                    unit: isCurrent ? "mA" : "V",
+                    value: isCurrent ? ch.current : ch.voltage
+                };
+            });
+
+            // payload is the four resolved values in channel order, for
+            // wiring straight into a chart or a function node that just
+            // wants numbers; channels carries the same values with their
+            // type/unit made explicit; moduleStatus is the raw, unfiltered
+            // server response (both current and voltage for all channels).
+            msg.moduleStatus = body;
+            msg.channels = resolved;
+            msg.payload = resolved.map(function (c) { return c.value; });
+
+            node.status({
+                fill: "green", shape: "dot",
+                text: resolved.map(function (c) { return c.value.toFixed(2) + c.unit; }).join(" / ")
+            });
+            nodeSend(msg);
+            nodeDone();
+        };
+    }
+
+    function handleError(node, msg, nodeSend, nodeDone, url) {
+        return function (err) {
+            if (err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT') {
+                node.error(RED._("common.notification.errors.no-response"), msg);
+                node.status({ fill: "red", shape: "ring", text: "common.notification.errors.no-response" });
+            } else {
+                node.error(err, msg);
+                node.status({ fill: "red", shape: "ring", text: err.code });
+            }
+            msg.payload = err.toString() + " : " + url;
+            msg.statusCode = err.code || (err.response ? err.response.statusCode : undefined);
+            nodeDone();
+        };
+    }
+
+    function SmartPiAnalogIn(config) {
+
+        var needle = require('needle');
+
+        RED.nodes.createNode(this, config);
+        var node = this;
+        this.indicator = config.indicator;
+        this.server = config.server;
+        this.address = config.address;
+        // One boolean per physical channel/jumper, in channel order: true =
+        // that channel is wired for 4-20mA (report the current reading),
+        // false = 0-10V (report the voltage reading). The server cannot
+        // read the jumper itself, so it always returns both - see
+        // handleResponse above, which is where this is actually used.
+        this.channelTypes = config.channelTypes || [true, true, true, true];
+        // See smartpi-modules-digital-out.js for why this is read from
+        // this.credentials rather than config, and why the ternary guard
+        // (rather than this.credentials.token directly) is needed for a
+        // node that has never had a credential saved.
+        this.token = this.credentials ? this.credentials.token : undefined;
+
+        var status = [];
+        if (!this.token) {
+            status.push("no token configured");
+        }
+        if (!/^0[xX][0-9a-fA-F]+$/.test(this.address || "")) {
+            status.push("address is not a hex value");
+        }
+        if (status.length > 0) {
+            node.status({ fill: "yellow", shape: "ring", text: status.join(", ") });
+        }
+
+        // This module has no "set" concept - reading is the only thing it
+        // does, whether triggered by an input message (its payload is
+        // ignored, it is only a trigger) or by the poll timer below.
+        function read(msg, nodeSend, nodeDone) {
+            var opts = {};
+            opts.headers = {};
+            opts.headers.Authorization = `Bearer ${node.token || ""}`;
+
+            var url = node.server + "/api/v1/module/analogin/" + node.address;
+            var options = {
+                json: true,
+                headers: { authorization: opts.headers.Authorization }
+            };
+
+            needle("get", url, null, options)
+                .then(handleResponse(node, msg, nodeSend, nodeDone))
+                .catch(handleError(node, msg, nodeSend, nodeDone, url));
+        }
+
+        // Optional independent polling, same as the other SmartPi modules:
+        // 0 (default) disables it entirely, a positive interval in seconds
+        // reads all four channels on that schedule regardless of input.
+        var pollInterval = Number(config.pollInterval);
+        var pollTimer = null;
+        if (pollInterval > 0) {
+            pollTimer = setInterval(function () {
+                read({}, function (msg) { node.send(msg); }, function () {});
+            }, pollInterval * 1000);
+        }
+        node.on('close', function (done) {
+            if (pollTimer) {
+                clearInterval(pollTimer);
+                pollTimer = null;
+            }
+            done();
+        });
+
+        node.on('input', function (msg, nodeSend, nodeDone) {
+            read(msg, nodeSend, nodeDone);
+        });
+    }
+
+    // The credentials schema also has to be declared here, server-side, not
+    // just in the .html file's client-side registerType() call - see
+    // smartpi-modules-digital-out.js, where getting only the client-side
+    // half of this right meant every save silently failed with "Credentials
+    // type ... is not registered".
+    RED.nodes.registerType("smartpi-e.analog-in", SmartPiAnalogIn, {
+        credentials: {
+            token: { type: "password" }
+        }
+    });
+}


### PR DESCRIPTION
Companion to nDenerserve/SmartPi#281.

New node "e.analog IN" (`smartpi-e.analog-in`), same shape as the other module nodes: server field, API token credential (registered both client- and server-side), explicit error handling for 401 and any other non-2xx response, and a status ring visible without triggering the node when the token or address is missing/malformed.

Reads all four channels of the analog-in module in one request. The server cannot tell which jumper each channel is wired for (4-20mA or 0-10V), so it always returns both readings for every channel - this node resolves the ambiguity locally. Config gets four toggle switches, one per physical channel/jumper (same slider UI as digital-out's address bits, but each one independently meaningful rather than together encoding a single value): on = 4-20mA, off = 0-10V. Defaults to all four on if never configured.

`msg.payload` is the four resolved values in channel order, already in the right unit, for wiring straight into a chart. `msg.channels` carries the same four readings as `{channel, type, unit, value}` objects. `msg.moduleStatus` is the server's raw, unfiltered response for flows that want the other interpretation too.

This module has no "set" - it is a pure sensor read, so any input message is just a trigger, its payload ignored. Same optional "Poll interval (s)" field as the other two modules (`0` disables it), built in from the start here.

Registered in `package.json` as `e.analog IN`, version bumped to 0.2.8.

### Verification

Against a stubbed `RED` runtime and a mocked `needle`, not just parsed: a mixed channel configuration (current/voltage/current/voltage) resolves each channel correctly in both `payload` and `channels`; the default (unset) configuration resolves every channel as current; polling fires repeatedly at the configured interval and stops on `node.on('close')` with no further calls afterwards; a `401` sets a red ring, calls `node.error()`, and never calls `nodeSend`; missing token and a non-hex address both show up together in one status ring. No live Node-RED instance or SmartPi server available here to test end-to-end.